### PR TITLE
Fix clippy unnecessary_unwrap warnings

### DIFF
--- a/src/solvers/alm.rs
+++ b/src/solvers/alm.rs
@@ -2192,7 +2192,7 @@ impl AlmRegressor {
 
         // Use standard errors based on (X'WX)^{-1} approximation
         // For simplicity, use the OLS-based standard errors
-        if result.intercept.is_some() {
+        if let Some(intercept) = result.intercept {
             if let Ok((se, se_int)) =
                 CoefficientInference::standard_errors_with_intercept(x, result.mse, &result.aliased)
             {
@@ -2212,7 +2212,6 @@ impl AlmRegressor {
                 result.conf_interval_upper = Some(ci_upper);
 
                 // Intercept inference
-                let intercept = result.intercept.expect("intercept was computed");
                 let t_int = if se_int > 0.0 {
                     intercept / se_int
                 } else {

--- a/src/solvers/bls.rs
+++ b/src/solvers/bls.rs
@@ -680,13 +680,13 @@ impl BlsRegressorBuilder {
         // Store the "all" bounds for later expansion
         BlsRegressor {
             options: self.options_builder.build_unchecked(),
-            lower_bounds: if self.lower_bound_all.is_some() {
-                Some(vec![self.lower_bound_all.expect("lower bound was set")])
+            lower_bounds: if let Some(lb) = self.lower_bound_all {
+                Some(vec![lb])
             } else {
                 lower
             },
-            upper_bounds: if self.upper_bound_all.is_some() {
-                Some(vec![self.upper_bound_all.expect("upper bound was set")])
+            upper_bounds: if let Some(ub) = self.upper_bound_all {
+                Some(vec![ub])
             } else {
                 upper
             },

--- a/src/solvers/ols.rs
+++ b/src/solvers/ols.rs
@@ -440,7 +440,7 @@ impl OlsRegressor {
 
         // Use the augmented design matrix method for models with intercept
         // This computes SE for both intercept and coefficients correctly
-        if result.intercept.is_some() {
+        if let Some(intercept) = result.intercept {
             match CoefficientInference::standard_errors_with_intercept(
                 x,
                 result.mse,
@@ -468,7 +468,6 @@ impl OlsRegressor {
                     result.conf_interval_upper = Some(ci_upper);
 
                     // Intercept inference
-                    let intercept = result.intercept.expect("intercept was computed");
                     let t_int = if se_int > 0.0 {
                         intercept / se_int
                     } else {

--- a/src/solvers/wls.rs
+++ b/src/solvers/wls.rs
@@ -551,7 +551,7 @@ impl WlsRegressor {
 
         // Use the weighted augmented design matrix method for models with intercept
         // This computes SE for both intercept and coefficients correctly
-        if result.intercept.is_some() {
+        if let Some(intercept) = result.intercept {
             match CoefficientInference::standard_errors_wls_with_intercept(
                 x,
                 weights,
@@ -576,7 +576,6 @@ impl WlsRegressor {
                     result.conf_interval_upper = Some(ci_upper);
 
                     // Intercept inference
-                    let intercept = result.intercept.expect("intercept was computed");
                     let t_int = if se_int > 0.0 {
                         intercept / se_int
                     } else {


### PR DESCRIPTION
## Summary

- Replace `if x.is_some() { x.expect(...) }` with idiomatic `if let Some(v) = x` in 4 files
- Fixes CI clippy job that was failing on main

## Test plan

- [x] `cargo clippy -- -D warnings` passes cleanly
- [x] All tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)